### PR TITLE
Revert "refactor: move template's friendly_name to attributes dict"

### DIFF
--- a/packages/aggregates/batteries.yaml
+++ b/packages/aggregates/batteries.yaml
@@ -1,3 +1,8 @@
+homeassistant:
+  customize:
+    binary_sensor.all_batteries:
+      friendly_name: "All batteries"
+
 group:
   all_batteries:
     name: "Batteries"
@@ -43,7 +48,6 @@ template:
 
         {{ n.entities | length != 0 }}
       attributes:
-        friendly_name: "All batteries"
         entity_id: >-
           {% set ns = namespace(entities = []) %}
 

--- a/packages/aggregates/doors.yaml
+++ b/packages/aggregates/doors.yaml
@@ -1,3 +1,8 @@
+homeassistant:
+  customize:
+    binary_sensor.all_doors:
+      friendly_name: "All doors"
+
 group:
   all_doors:
     name: "All doors"
@@ -19,7 +24,6 @@ template:
             | length != 0
         }}
       attributes:
-        friendly_name: "All doors"
         entity_id: >-
           {{
             expand('group.all_doors')

--- a/packages/aggregates/leaks.yaml
+++ b/packages/aggregates/leaks.yaml
@@ -1,3 +1,8 @@
+homeassistant:
+  customize:
+    binary_sensor.all_leaks:
+      friendly_name: "All leaks"
+
 group:
   all_leaks:
     name: "All leaks"
@@ -26,7 +31,6 @@ template:
             | length != 0
         }}
       attributes:
-        friendly_name: "All leaks"
         entity_id: >-
           {{
             expand('group.all_leaks')

--- a/packages/aggregates/motions.yaml
+++ b/packages/aggregates/motions.yaml
@@ -1,3 +1,10 @@
+homeassistant:
+  customize:
+    binary_sensor.all_motions:
+      friendly_name: "All motions"
+    sensor.last_motion:
+      friendly_name: "Last motion"
+
 group:
   all_motions:
     name: "All motions"
@@ -21,7 +28,6 @@ template:
             | length != 0
         }}
       attributes:
-        friendly_name: "All motions"
         entity_id: >-
           {{
             expand('group.all_motions')
@@ -42,5 +48,3 @@ template:
             | first
             | replace(' motion', '')
         }}
-      attributes:
-        friendly_name: "Last motion"

--- a/packages/aggregates/windows.yaml
+++ b/packages/aggregates/windows.yaml
@@ -1,3 +1,8 @@
+homeassistant:
+  customize:
+    binary_sensor.all_windows:
+      friendly_name: "All windows"
+
 group:
   all_windows:
     name: "All windows"
@@ -20,7 +25,6 @@ template:
             | length != 0
         }}
       attributes:
-        friendly_name: "All windows"
         entity_id: >-
           {{
             expand('group.all_windows')

--- a/packages/areas/basement_bathroom.yaml
+++ b/packages/areas/basement_bathroom.yaml
@@ -1,10 +1,15 @@
 homeassistant:
   customize:
     binary_sensor.basement_bathroom_door:
+      friendly_name: "Basement bathroom door"
       device_class: "door"
+    binary_sensor.basement_bathroom_presence:
+      friendly_name: "Basement bathroom presence"
     sensor.basement_bathroom_door_sensor_battery:
       battery_type: "Sensative Strip"
       battery_warning_level: 20
+    sensor.basement_bathroom_humidity:
+      friendly_name: "Basement bathroom humidity"
     sensor.basement_bathroom_multisensor_battery:
       battery_type: "CR123A"
       battery_warning_level: 40
@@ -44,8 +49,6 @@ template:
             or is_state('binary_sensor.basement_bathroom_door', 'off')
         }}
       delay_off: 15
-      attributes:
-        friendly_name: "Basement bathroom presence"
 
   sensor:
     - unique_id: "sensor.basement_bathroom_humidity"
@@ -53,8 +56,6 @@ template:
       device_class: "humidity"
       unit_of_measurement: "%"
       state: "{{ states('sensor.basement_bathroom_multisensor_relative_humidity') | round }}"
-      attributes:
-        friendly_name: "Basement bathroom humidity"
 
 sensor:
   - platform: min_max

--- a/packages/areas/basement_general.yaml
+++ b/packages/areas/basement_general.yaml
@@ -1,5 +1,7 @@
 homeassistant:
   customize:
+    sensor.basement_hallway_temperature:
+      friendly_name: "Basement hallway temperature"
     light.downstairs:
       friendly_name: "Downstairs light"
 
@@ -66,8 +68,6 @@ template:
       device_class: "temperature"
       unit_of_measurement: "°C"
       state: "{{ states('sensor.basement_hallway_thermostat_temperature') | round(1) }}"
-      attributes:
-        friendly_name: "Basement hallway temperature"
 
 automation:
   - id: "a2df600b-4450-4a6f-8c3d-ad3f4ea5773c"

--- a/packages/areas/dining_room.yaml
+++ b/packages/areas/dining_room.yaml
@@ -2,6 +2,8 @@ homeassistant:
   customize:
     light.hallway:
       friendly_name: "Hallway light"
+    sensor.dining_room_temperature:
+      friendly_name: "Dining room temperature"
 
 cloud:
   google_actions:
@@ -68,8 +70,6 @@ template:
       device_class: "temperature"
       unit_of_measurement: "°C"
       state: "{{ states('sensor.dining_room_thermostat_temperature') | round(1) }}"
-      attributes:
-        friendly_name: "Dining room temperature"
 
 automation:
   - id: "7a81bc8a-fc13-426e-b324-e2c76c1142d7"

--- a/packages/areas/guest_bedroom.yaml
+++ b/packages/areas/guest_bedroom.yaml
@@ -1,6 +1,7 @@
 homeassistant:
   customize:
     binary_sensor.guest_bedroom_window:
+      friendly_name: "Guest bedroom window"
       device_class: "window"
     light.guest_bedroom:
       friendly_name: "Guest bedroom light"
@@ -9,6 +10,8 @@ homeassistant:
     sensor.guest_bedroom_window_sensor_battery:
       battery_type: "Sensative Strip"
       battery_warning_level: 20
+    sensor.guest_bedroom_temperature:
+      friendly_name: "Guest bedroom temperature"
 
 cloud:
   google_actions:
@@ -77,5 +80,3 @@ template:
       device_class: "temperature"
       unit_of_measurement: "°C"
       state: "{{ states('sensor.guest_bedroom_thermostat_temperature') | round(1) }}"
-      attributes:
-        friendly_name: "Guest bedroom temperature"

--- a/packages/areas/kitchen.yaml
+++ b/packages/areas/kitchen.yaml
@@ -1,6 +1,7 @@
 homeassistant:
   customize:
     binary_sensor.kitchen_door:
+      friendly_name: "Kitchen door"
       device_class: "door"
     sensor.kitchen_door_sensor_battery:
       battery_type: "Sensative Strip"
@@ -8,6 +9,8 @@ homeassistant:
     sensor.kitchen_sink_leak_sensor_battery:
       battery_type: "ER14250 3.6V"
       battery_warning_level: 25
+    sensor.kitchen_temperature:
+      friendly_name: "Kitchen temperature"
     light.kitchen:
       friendly_name: "Kitchen light"
     light.kitchen_sink:
@@ -51,8 +54,6 @@ template:
       unit_of_measurement: "°C"
       # Living room and Kitchen thermostat are the same
       state: "{{ states('sensor.living_room_thermostat_temperature') | round(1) }}"
-      attributes:
-        friendly_name: "Kitchen temperature"
 
 automation:
   - id: "ab8460a3-e7b3-4cef-989e-11a65da297f9"

--- a/packages/areas/living_room.yaml
+++ b/packages/areas/living_room.yaml
@@ -1,6 +1,7 @@
 homeassistant:
   customize:
     binary_sensor.living_room_door:
+      friendly_name: "Living room door"
       device_class: "door"
     light.living_room_ambiance:
       friendly_name: "Living room ambiance"
@@ -9,6 +10,8 @@ homeassistant:
     sensor.living_room_door_sensor_battery:
       battery_type: "Sensative Strip"
       battery_warning_level: 20
+    sensor.living_room_temperature:
+      friendly_name: "Living room temperature"
     switch.bookshelf_outlet:
       friendly_name: "Bookshelf outlet"
     switch.living_room_ambiance:
@@ -100,8 +103,6 @@ template:
       device_class: "temperature"
       unit_of_measurement: "°C"
       state: "{{ states('sensor.living_room_thermostat_temperature') | round(1) }}"
-      attributes:
-        friendly_name: "Living room temperature"
 
 automation:
   - id: "00a013b0-caf0-4046-b701-21975ffbfe3f"

--- a/packages/areas/lounge.yaml
+++ b/packages/areas/lounge.yaml
@@ -1,10 +1,13 @@
 homeassistant:
   customize:
     binary_sensor.lounge_window:
+      friendly_name: "Lounge window"
       device_class: "window"
     sensor.lounge_window_sensor_battery:
       battery_type: "Sensative Strip"
       battery_warning_level: 20
+    sensor.lounge_temperature:
+      friendly_name: "Lounge temperature"
     switch.lounge_tv:
       friendly_name: "Living room TV"
 
@@ -72,8 +75,6 @@ template:
       device_class: "temperature"
       unit_of_measurement: "°C"
       state: "{{ states('sensor.lounge_thermostat_temperature') | round(1) }}"
-      attributes:
-        friendly_name: "Lounge temperature"
 
 switch:
   - platform: broadlink

--- a/packages/areas/main_bathroom.yaml
+++ b/packages/areas/main_bathroom.yaml
@@ -1,8 +1,16 @@
 homeassistant:
   customize:
+    binary_sensor.main_bathroom_door:
+      friendly_name: "Main bathroom door"
+    binary_sensor.main_bathroom_presence:
+      friendly_name: "Main bathroom presence"
     sensor.main_bathroom_multisensor_battery:
       battery_type: "CR123A"
       battery_warning_level: 40
+    sensor.main_bathroom_humidity:
+      friendly_name: "Main bathroom humidity"
+    sensor.main_bathroom_temperature:
+      friendly_name: "Main bathroom temperature"
     light.main_bathroom_vanity:
       friendly_name: "Main bathroom vanity light"
 
@@ -40,8 +48,6 @@ template:
       name: "main_bathroom_door"
       device_class: "door"
       state: true
-      attributes:
-        friendly_name: "Main bathroom door"
 
     - unique_id: "binary_sensor.main_bathroom_presence"
       name: "main_bathroom_presence"
@@ -52,8 +58,6 @@ template:
             or is_state('binary_sensor.main_bathroom_door', 'off')
         }}
       delay_off: 15
-      attributes:
-        friendly_name: "Main bathroom presence"
 
   sensor:
     - unique_id: "sensor.main_bathroom_humidity"
@@ -61,16 +65,12 @@ template:
       device_class: "humidity"
       unit_of_measurement: "%"
       state: "{{ states('sensor.main_bathroom_multisensor_relative_humidity') | round }}"
-      attributes:
-        friendly_name: "Main bathroom humidity"
 
     - unique_id: "sensor.main_bathroom_temperature"
       name: "main_bathroom_temperature"
       device_class: "temperature"
       unit_of_measurement: "°C"
       state: "{{ states('sensor.main_bathroom_multisensor_temperature') | round(1) }}"
-      attributes:
-        friendly_name: "Main bathroom temperature"
 
 fan:
   - platform: template

--- a/packages/areas/master_bedroom/master_bedroom.yaml
+++ b/packages/areas/master_bedroom/master_bedroom.yaml
@@ -4,6 +4,8 @@ homeassistant:
       friendly_name: "Master bedroom's bedside lamps"
     light.master_bedroom:
       friendly_name: "Master bedroom light"
+    sensor.master_bedroom_temperature:
+      friendly_name: "Master bedroom temperature"
 
 cloud:
   google_actions:
@@ -86,8 +88,6 @@ template:
       device_class: "temperature"
       unit_of_measurement: "°C"
       state: "{{ states('sensor.master_bedroom_thermostat_temperature') | round(1) }}"
-      attributes:
-        friendly_name: "Master bedroom temperature"
 
 automation:
   - id: "650fdbf6-2f22-4bd0-b430-c8a1c29d3217"

--- a/packages/areas/office.yaml
+++ b/packages/areas/office.yaml
@@ -1,3 +1,8 @@
+homeassistant:
+  customize:
+    sensor.office_temperature:
+      friendly_name: "Office temperature"
+
 cloud:
   google_actions:
     filter:
@@ -50,8 +55,6 @@ template:
       device_class: "temperature"
       unit_of_measurement: "°C"
       state: "{{ states('sensor.office_thermostat_temperature') | round(1) }}"
-      attributes:
-        friendly_name: "Office temperature"
 
 sonos:
   media_player:

--- a/packages/areas/outdoor.yaml
+++ b/packages/areas/outdoor.yaml
@@ -6,6 +6,12 @@ homeassistant:
       friendly_name: "Side porch light"
     light.shed_outdoor:
       friendly_name: "Shed outdoor light"
+    sensor.outdoor_humidity:
+      friendly_name: "Outdoor humidity"
+    sensor.outdoor_temperature:
+      friendly_name: "Outdoor temperature"
+    sensor.weather_summary:
+      friendly_name: "Weather summary"
 
 cloud:
   google_actions:
@@ -64,16 +70,12 @@ template:
       unit_of_measurement: "%"
       state: "{{ states('sensor.weather_quebec_humidity') }}"
       availability: "{{ not is_state('sensor.weather_quebec_humidity', 'unavailable') }}"
-      attributes:
-        friendly_name: "Outdoor humidity"
     - unique_id: "sensor.outdoor_temperature"
       name: "outdoor_temperature"
       device_class: "temperature"
       unit_of_measurement: "°C"
       state: "{{ states('sensor.weather_quebec_temperature') }}"
       availability: "{{ not is_state('sensor.weather_quebec_temperature', 'unavailable') }}"
-      attributes:
-        friendly_name: "Outdoor temperature"
     - unique_id: "sensor.weather_summary"
       name: "weather_summary"
       state: "{{ states('sensor.weather_quebec_forecast') }}"
@@ -85,8 +87,6 @@ template:
           | replace('exceptional', '') %}
         mdi:{% if state_icon %}weather-{{ state_icon }}{% else %}help-circle{% endif %}
       availability: "{{ not is_state('sensor.weather_quebec_forecast', 'unavailable') }}"
-      attributes:
-        friendly_name: "Weather summary"
 
 automation:
   - id: "abe8645a-9131-4822-8877-631f62b3e716"

--- a/packages/areas/studio.yaml
+++ b/packages/areas/studio.yaml
@@ -1,12 +1,15 @@
 homeassistant:
   customize:
     binary_Sensor.studio_window:
+      friendly_name: "Studio window"
       device_class: "window"
     light.studio:
       friendly_name: "Studio light"
     sensor.studio_window_sensor_battery:
       battery_type: "Sensative Strip"
       battery_warning_level: 20
+    sensor.studio_temperature:
+      friendly_name: "Studio temperature"
 
 cloud:
   google_actions:
@@ -64,5 +67,3 @@ template:
       device_class: "temperature"
       unit_of_measurement: "°C"
       state: "{{ states('sensor.studio_thermostat_temperature') | round(1) }}"
-      attributes:
-        friendly_name: "Studio temperature"

--- a/packages/climate/mode.yaml
+++ b/packages/climate/mode.yaml
@@ -1,3 +1,8 @@
+homeassistant:
+  customize:
+    sensor.manual_thermostats_count:
+      friendly_name: "Thermostats in manual mode"
+
 group:
   managed_thermostats:
     name: "Managed thermostats"
@@ -90,7 +95,6 @@ template:
             | count
         }}
       attributes:
-        friendly_name: "Thermostats in manual mode"
         entity_id: |
           {{
             expand('group.managed_thermostat_modes')

--- a/packages/climate/scheduling.yaml
+++ b/packages/climate/scheduling.yaml
@@ -1,3 +1,8 @@
+homeassistant:
+  customize:
+    sensor.scheduled_climate_preset:
+      friendly_name: "Scheduled climate preset"
+
 template:
   sensor:
     - unique_id: "sensor.scheduled_climate_preset"
@@ -37,8 +42,6 @@ template:
         {% endif -%}
 
         {{ parse_calendar_preset('calendar.special_climate_schedule', preset) }}
-      attributes:
-        friendly_name: "Scheduled climate preset"
 
 script:
   assign_climate_auto_mode:

--- a/packages/climate/winter_credit.yaml
+++ b/packages/climate/winter_credit.yaml
@@ -3,6 +3,11 @@
 #   `Peak demand event notification - Winter Credit Option: tomorrow, Jan. 19, from 4 to 8 p.m.`
 #   `Peak demand event notification - Winter Credit Option: tomorrow, Jan. 21, from 6 to 9 a.m. and from 4 to 8 p.m.`
 
+homeassistant:
+  customize:
+    sensor.winter_credit_baseline_climate_preset:
+      friendly_name: "Winter credit: baseline climate preset"
+
 template:
   binary_sensor:
     - unique_id: "4ff23e99-f31f-4b96-9cb8-dd53b3796354"
@@ -14,15 +19,11 @@ template:
             and date_sensor.last_changed.month <= 3
             or date_sensor.last_changed.month == 12
         }}
-      attributes:
-        friendly_name: "Winter credit enabled"
     - unique_id: "42ce95f4-91ce-41dd-8d33-61fba466e7f6"
       name: "winter_credit_peak_event"
       state: >-
         {% set special_schedule = state_attr('calendar.special_climate_schedule', 'message') | default('', True) -%}
         {{ 'Winter Credit: Peak Event' in special_schedule }}
-      attributes:
-        friendly_name: "Ongoing winter credit peak event"
 
   sensor:
     - unique_id: "sensor.winter_credit_baseline_climate_preset"
@@ -47,8 +48,6 @@ template:
         {% endif %}
 
         {{ ns.preset }}
-      attributes:
-        friendly_name: "Winter credit: baseline climate preset"
 
 automation:
   - id: "dc44848a-cdb1-4b0b-bd76-711a2f81e4b2"

--- a/packages/infrastructure/system.yaml
+++ b/packages/infrastructure/system.yaml
@@ -9,6 +9,8 @@ homeassistant:
     sensor.memory_use_percent:
       friendly_name: "Memory use"
       icon: "mdi:memory"
+    sensor.hour:
+      friendly_name: "Hour"
 
 sensor:
   - platform: time_date
@@ -33,5 +35,3 @@ template:
       name: "hour"
       icon: "mdi:clock"
       state: "{{ states.sensor.time.last_changed.hour }}"
-      attributes:
-        friendly_name: "Hour"

--- a/packages/infrastructure/ups.yaml
+++ b/packages/infrastructure/ups.yaml
@@ -1,3 +1,10 @@
+homeassistant:
+  customize:
+    sensor.ups_battery_status:
+      battery_type: "APC BR1500G RS 1500 12V"
+      battery_warning_level: 0
+      friendly_name: "UPS battery status"
+
 apcupsd:
   host: !secret ups_host
   port: !secret ups_port
@@ -23,10 +30,6 @@ template:
       unit_of_measurement: "%"
       state: >-
         {% if 'REPLACEBATT' in states('sensor.ups_status') %}0{% else %}100{% endif %}
-      attributes:
-        battery_type: "APC BR1500G RS 1500 12V"
-        battery_warning_level: 0
-        friendly_name: "UPS battery status"
 
 input_boolean:
   power_outage_manage_devices:

--- a/packages/livings/carl.yaml
+++ b/packages/livings/carl.yaml
@@ -1,5 +1,13 @@
 homeassistant:
   customize:
+    binary_sensor.carl_requires_attention:
+      friendly_name: "Carl requires attention"
+    sensor.carl_basking_temperature:
+      friendly_name: "Carl's basking spot temperature"
+    sensor.carl_temperature:
+      friendly_name: "Carl's terrarium temperature"
+    sensor.carl_humidity:
+      friendly_name: "Carl's terrarium humidity"
     switch.carl_heat_bulb:
       icon: "mdi:spotlight-beam"
     switch.carl_heater:
@@ -33,7 +41,6 @@ template:
       device_class: "problem"
       picture: "/local/animals/carl_avatar.jpg"
       attributes:
-        friendly_name: "Carl requires attention"
         scheduling: "{{ is_state('input_boolean.carl_scheduled_lights', 'on') }}"
         heat_bulb: "{{ is_state('switch.carl_heat_bulb', 'off') or states('sensor.carl_heat_bulb_power') | float > 1 }}"
         heater: "{{ is_state('switch.carl_heater', 'off') or states('sensor.carl_heater_power') | float > 1 }}"
@@ -51,22 +58,16 @@ template:
       device_class: "temperature"
       unit_of_measurement: "°C"
       state: "0.0"
-      attributes:
-        friendly_name: "Carl's basking spot temperature"
     - unique_id: "sensor.carl_temperature"
       name: "carl_temperature"
       device_class: "temperature"
       unit_of_measurement: "°C"
       state: "0.0"
-      attributes:
-        friendly_name: "Carl's terrarium temperature"
     - unique_id: "sensor.carl_humidity"
       name: "carl_humidity"
       device_class: "humidity"
       unit_of_measurement: "%"
       state: "0.0"
-      attributes:
-        friendly_name: "Carl's terrarium humidity"
 
 automation:
   - id: "b61cbb0c-2aa9-4094-959e-a5eb20037f52"

--- a/packages/livings/dollorama.yaml
+++ b/packages/livings/dollorama.yaml
@@ -2,6 +2,8 @@ homeassistant:
   customize:
     plant.dollorama:
       friendly_name: "Dollorama"
+    sensor.dollorama_problems:
+      friendly_name: "Dollorama"
     sensor.dollorama_battery:
       friendly_name: "Dollorama's battery"
       battery_type: "CR2032"
@@ -35,8 +37,6 @@ template:
     - unique_id: "sensor.dollorama_problems"
       name: "dollorama_problems"
       state: "{{ state_attr('plant.dollorama', 'problem') or 'none' }}"
-      attributes:
-        friendly_name: "Dollorama"
 
 sensor:
   - platform: mqtt

--- a/packages/livings/drake.yaml
+++ b/packages/livings/drake.yaml
@@ -2,6 +2,8 @@ homeassistant:
   customize:
     plant.drake:
       friendly_name: "Drake"
+    sensor.drake_problems:
+      friendly_name: "Drake"
     sensor.drake_battery:
       friendly_name: "Drake's battery"
       battery_type: "CR2032"
@@ -36,8 +38,6 @@ template:
     - unique_id: "sensor.drake_problems"
       name: "drake_problems"
       state: "{{ state_attr('plant.drake', 'problem') or 'none' }}"
-      attributes:
-        friendly_name: "Drake"
 
 sensor:
   - platform: mqtt

--- a/packages/livings/maitre_doyle.yaml
+++ b/packages/livings/maitre_doyle.yaml
@@ -2,6 +2,8 @@ homeassistant:
   customize:
     plant.maitre_doyle:
       friendly_name: "Maître Doyle"
+    sensor.maitre_doyle_problems:
+      friendly_name: "Maître Doyle"
     sensor.maitre_doyle_battery:
       friendly_name: "Maître Doyle's battery"
       battery_type: "CR2032"
@@ -35,8 +37,6 @@ template:
     - unique_id: "sensor.maitre_doyle_problems"
       name: "maitre_doyle_problems"
       state: "{{ state_attr('plant.maitre_doyle', 'problem') or 'none' }}"
-      attributes:
-        friendly_name: "Maître Doyle"
 
 sensor:
   - platform: mqtt

--- a/packages/livings/plants.yaml
+++ b/packages/livings/plants.yaml
@@ -1,3 +1,8 @@
+homeassistant:
+  customize:
+    binary_sensor.all_plants:
+      friendly_name: "All plants"
+
 group:
   all_plants:
     name: "All plants"
@@ -29,7 +34,6 @@ template:
             | length != 0
         }}
       attributes:
-        friendly_name: "All plants"
         entity_id: >-
           {{
             expand('group.all_plants')

--- a/packages/livings/slinky.yaml
+++ b/packages/livings/slinky.yaml
@@ -1,5 +1,13 @@
 homeassistant:
   customize:
+    binary_sensor.slinky_requires_attention:
+      friendly_name: "Slinky requires attention"
+    sensor.slinky_basking_temperature:
+      friendly_name: "Slinky's basking spot temperature"
+    sensor.slinky_temperature:
+      friendly_name: "Slinky's terrarium temperature"
+    sensor.slinky_humidity:
+      friendly_name: "Slinky's terrarium humidity"
     switch.slinky_heat_bulb:
       icon: "mdi:spotlight-beam"
     switch.slinky_heater:
@@ -33,7 +41,6 @@ template:
       device_class: "problem"
       picture: "/local/animals/slinky_avatar.jpg"
       attributes:
-        friendly_name: "Slinky requires attention"
         scheduling: "{{ is_state('input_boolean.slinky_scheduled_lights', 'on') }}"
         heat_bulb: "{{ is_state('switch.slinky_heat_bulb', 'off') or states('sensor.slinky_heat_bulb_power') | float > 1 }}"
         heater: "{{ is_state('switch.slinky_heater', 'off') or states('sensor.slinky_heater_power') | float > 1 }}"
@@ -51,22 +58,16 @@ template:
       device_class: "temperature"
       unit_of_measurement: "°C"
       state: "0.0"
-      attributes:
-        friendly_name: "Slinky's basking spot temperature"
     - unique_id: "sensor.slinky_temperature"
       name: "slinky_temperature"
       device_class: "temperature"
       unit_of_measurement: "°C"
       state: "0.0"
-      attributes:
-        friendly_name: "Slinky's terrarium temperature"
     - unique_id: "sensor.slinky_humidity"
       name: "slinky_humidity"
       device_class: "humidity"
       unit_of_measurement: "%"
       state: "0.0"
-      attributes:
-        friendly_name: "Slinky's terrarium humidity"
 
 automation:
   - id: "ca115276-80d4-4a82-bd6e-b575f6483b64"

--- a/packages/livings/snicket.yaml
+++ b/packages/livings/snicket.yaml
@@ -2,6 +2,8 @@ homeassistant:
   customize:
     plant.snicket:
       friendly_name: "Snicket"
+    sensor.snicket_problems:
+      friendly_name: "Snicket"
     sensor.snicket_battery:
       friendly_name: "Snicket's battery"
       battery_type: "CR2032"
@@ -36,8 +38,6 @@ template:
     - unique_id: "sensor.snicket_problems"
       name: "snicket_problems"
       state: "{{ state_attr('plant.snicket', 'problem') or 'none' }}"
-      attributes:
-        friendly_name: "Snicket"
 
 sensor:
   - platform: mqtt

--- a/packages/livings/spidy.yaml
+++ b/packages/livings/spidy.yaml
@@ -2,6 +2,8 @@ homeassistant:
   customize:
     plant.spidy:
       friendly_name: "Spidy"
+    sensor.spidy_problems:
+      friendly_name: "Spidy"
     sensor.spidy_battery:
       friendly_name: "Spidy's battery"
       battery_type: "CR2032"
@@ -35,8 +37,6 @@ template:
     - unique_id: "sensor.spidy_problems"
       name: "spidy_problems"
       state: "{{ state_attr('plant.spidy', 'problem') or 'none' }}"
-      attributes:
-        friendly_name: "Spidy"
 
 sensor:
   - platform: mqtt

--- a/packages/livings/viny.yaml
+++ b/packages/livings/viny.yaml
@@ -2,6 +2,8 @@ homeassistant:
   customize:
     plant.viny:
       friendly_name: "Viny"
+    sensor.viny_problems:
+      friendly_name: "Viny"
     sensor.viny_battery:
       friendly_name: "Viny's battery"
       battery_type: "CR2032"
@@ -35,8 +37,6 @@ template:
     - unique_id: "sensor.viny_problems"
       name: "viny_problems"
       state: "{{ state_attr('plant.viny', 'problem') or 'none' }}"
-      attributes:
-        friendly_name: "Viny"
 
 sensor:
   - platform: mqtt

--- a/packages/misc/car.yaml
+++ b/packages/misc/car.yaml
@@ -1,5 +1,9 @@
 homeassistant:
   customize:
+    binary_sensor.bolt_ev_network_link:
+      friendly_name: "Bolt EV network link"
+    binary_sensor.bolt_ev_recharge_recommended:
+      friendly_name: "Bolt EV recharge recommended"
     sensor.mychevy_2019_chevrolet_bolt_ev_electric_range:
       unit_of_measurement: "km"
     sensor.mychevy_2019_chevrolet_bolt_ev_mileage:
@@ -27,8 +31,6 @@ template:
         {% else %}
           mdi:network-strength-off
         {% endif %}
-      attributes:
-        friendly_name: "Bolt EV network link"
     - unique_id: "binary_sensor.bolt_ev_recharge_recommended"
       name: "bolt_ev_recharge_recommended"
       state: >-
@@ -47,8 +49,6 @@ template:
         {% else %}
           mdi:flash-off
         {% endif %}
-      attributes:
-        friendly_name: "Bolt EV recharge recommended"
 
 automation:
   - id: "38b66e01-1e27-4614-9bb1-2758a22a1e49"

--- a/packages/misc/default_theme.yaml
+++ b/packages/misc/default_theme.yaml
@@ -1,3 +1,10 @@
+homeassistant:
+  customize:
+    binary_sensor.use_alarm_theme:
+      friendly_name: "Use alarm theme"
+    binary_sensor.use_dark_theme:
+      friendly_name: "Use dark theme"
+
 template:
   binary_sensor:
     - unique_id: "d15e4446-af81-4000-aed1-98a0fe3c8702"
@@ -11,14 +18,10 @@ template:
           ) | selectattr('state', '==', 'on')
             | first is defined
         }}
-      attributes:
-        friendly_name: "Use alarm theme"
     - unique_id: "db252c59-897b-4bd9-94a8-d5d17f48ed68"
       name: "use_dark_theme"
       icon: "mdi:theme-light-dark"
       state: "{{ state_attr('sun.sun', 'elevation') | float < -3 }}"
-      attributes:
-        friendly_name: "Use dark theme"
 
 input_boolean:
   automatic_night_theme:

--- a/packages/presence/alarm.yaml
+++ b/packages/presence/alarm.yaml
@@ -1,3 +1,10 @@
+homeassistant:
+  customize:
+    binary_sensor.presence_armed:
+      friendly_name: "Armed"
+    binary_sensor.intrusion:
+      friendly_name: "Intrusion"
+
 input_boolean:
   force_presence_armed:
     name: "Force armed"
@@ -23,8 +30,6 @@ template:
             or not is_state('group.household', 'home')
             and is_state('binary_sensor.guest_mode', 'off')
         }}
-      attributes:
-        friendly_name: "Armed"
 
     - unique_id: "ccc872ad-92f9-4b3e-87a5-452292b6b118"
       name: "intrusion"
@@ -32,7 +37,6 @@ template:
       delay_on: 15
       delay_off: 15
       attributes:
-        friendly_name: "Intrusion"
         activity: >-
           {% set armed = states.binary_sensor.presence_armed -%}
           {% if armed is not none and armed.state == 'on' -%}

--- a/packages/presence/people.yaml
+++ b/packages/presence/people.yaml
@@ -1,9 +1,13 @@
 homeassistant:
   customize:
+    binary_sensor.guest_mode:
+      friendly_name: "Guest mode"
     person.chris:
       entity_picture: "/local/secrets/chris.webp"
     person.karine:
       entity_picture: "/local/secrets/karine.webp"
+    sensor.guests_home:
+      friendly_name: "Guests at home"
 
 person:
   - id: "chris"
@@ -58,8 +62,6 @@ template:
             or is_state('group.household', 'home')
             and state_attr('sensor.guests_home', 'count') | int | default(0) > 0
         }}
-      attributes:
-        friendly_name: "Guest mode"
 
   sensor:
     - unique_id: "sensor.guests_home"
@@ -75,7 +77,6 @@ template:
             | default('Nobody', true)
         }}
       attributes:
-        friendly_name: "Guests at home"
         count: >-
           {{
             expand('group.guests')


### PR DESCRIPTION
This reverts commit 9869d7dfccf3461a817cdc120b2dd86ffb13ee8d.

friendly_name doesn't work when specified as a `template:` attribute.